### PR TITLE
Fix vulnerabilities by upgrade rubygems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pkg
 .ruby-version
 .ruby-gemset
 /vendor
+
+# VSCcode
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ pkg
 # RVM files
 .ruby-version
 .ruby-gemset
+/vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,21 +8,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.4)
-      activesupport (= 7.0.4)
-    activerecord (7.0.4)
-      activemodel (= 7.0.4)
-      activesupport (= 7.0.4)
-    activesupport (7.0.4)
+    activemodel (7.0.4.3)
+      activesupport (= 7.0.4.3)
+    activerecord (7.0.4.3)
+      activemodel (= 7.0.4.3)
+      activesupport (= 7.0.4.3)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
-    minitest (5.17.0)
+    minitest (5.18.0)
     pg (1.4.5)
     psych (5.0.1)
       stringio
@@ -43,7 +43,7 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
     stringio (3.0.4)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS


### PR DESCRIPTION
Fix Vulnerabilities related to activerecord 7.0.4.1

This gem is used in https://github.com/accredible/accredible-data-export-api/