### PR TITLE
DVOPS-176 | Vuln Patching, bump activerecord to 7.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 # specify gem dependencies in activerecord-postgres-hstore.gemspec
 # except the platform-specific dependencies below
 gemspec
+
+gem "activerecord", "~> 7.1.2"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,21 +8,32 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.4.3)
-      activesupport (= 7.0.4.3)
-    activerecord (7.0.4.3)
-      activemodel (= 7.0.4.3)
-      activesupport (= 7.0.4.3)
-    activesupport (7.0.4.3)
+    activemodel (7.1.3.2)
+      activesupport (= 7.1.3.2)
+    activerecord (7.1.3.2)
+      activemodel (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      timeout (>= 0.4.0)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    concurrent-ruby (1.2.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.0)
-    i18n (1.13.0)
+    drb (2.2.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    minitest (5.18.0)
+    minitest (5.22.2)
+    mutex_m (0.2.0)
     pg (1.4.5)
     psych (5.0.1)
       stringio
@@ -43,6 +54,7 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
     stringio (3.0.4)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
@@ -50,6 +62,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord (~> 7.1.2)
   bundler
   postgres-copy!
   rake (~> 12.3.3)
@@ -57,4 +70,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.2.22
+   2.2.33


### PR DESCRIPTION
Change required to bump dependency `activesupport` in turn.

A PR in accredible-data-export-api will follow